### PR TITLE
start and duration as fractions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,17 +82,19 @@ const composeAssetClip = ({clipName, ref, start, duration, audioRole = 'dialogue
 
 
 const jsonToFCPX = (sequenceEDLJson)=>{
-    let counterIdAssetClips = 1;
-    // sequenceEDLJson.events 
-    const assetClips = sequenceEDLJson.events.map((event, index) => {
-        const durationFrames = (event.endTime - event.startTime) * 2500;
-        const roundedDuration = Math.ceil(durationFrames / 100) * 100; // removes clip boundary warning on FCPX import
+   const FRAME_RATE = 2500;
+   const ROUND_TO = 100;
+   let counterIdAssetClips = 1;
+   // sequenceEDLJson.events 
+   const assetClips = sequenceEDLJson.events.map((event, index) => {
+        const durationFrames = (event.endTime - event.startTime) * FRAME_RATE;
+        const roundedDuration = Math.round(durationFrames / ROUND_TO) * ROUND_TO; // rounding to 100 removes clip boundary warning on FCPX import
         const results = composeAssetClip( {
             clipName: event.clipName, 
-            ref:`r${ counterIdAssetClips }`,
-            start: `${ event.startTime * 2500 }/2500`,
-            duration: `${ roundedDuration }/2500`
-        })
+            ref:`r${counterIdAssetClips}`,
+            start: `${ event.startTime * FRAME_RATE }/${ FRAME_RATE }`,
+            duration: `${ roundedDuration }/${ FRAME_RATE }`
+       })
         counterIdAssetClips=counterIdAssetClips+2;
         return results;
     })
@@ -107,7 +109,7 @@ const jsonToFCPX = (sequenceEDLJson)=>{
 
         const results = composeAsset( {id: `r${counterId}`, 
             src: event.clipName, 
-            start: event.startTime, 
+            start: 0, 
             duration: event.endTime,
             // hasVideo = 1, 
             // hasAudio = 1, 

--- a/src/index.js
+++ b/src/index.js
@@ -84,12 +84,14 @@ const composeAssetClip = ({clipName, ref, start, duration, audioRole = 'dialogue
 const jsonToFCPX = (sequenceEDLJson)=>{
     let counterIdAssetClips = 1;
     // sequenceEDLJson.events 
-    const assetClips = sequenceEDLJson.events.map((event, index)=>{
-        const results = composeAssetClip({
+    const assetClips = sequenceEDLJson.events.map((event, index) => {
+        const durationFrames = (event.endTime - event.startTime) * 2500;
+        const roundedDuration = Math.ceil(durationFrames / 100) * 100; // removes clip boundary warning on FCPX import
+        const results = composeAssetClip( {
             clipName: event.clipName, 
-            ref:`r${counterIdAssetClips}`,
-            start: event.startTime,
-            duration: event.endTime - event.startTime
+            ref:`r${ counterIdAssetClips }`,
+            start: `${ event.startTime * 2500 }/2500`,
+            duration: `${ roundedDuration }/2500`
         })
         counterIdAssetClips=counterIdAssetClips+2;
         return results;
@@ -106,7 +108,7 @@ const jsonToFCPX = (sequenceEDLJson)=>{
         const results = composeAsset( {id: `r${counterId}`, 
             src: event.clipName, 
             start: event.startTime, 
-            duration: event.endTime - event.startTime,
+            duration: event.endTime,
             // hasVideo = 1, 
             // hasAudio = 1, 
             formatId: `r${counterId+1}`, 


### PR DESCRIPTION
FCPX XML start and duration values don't accept decimals, so will round to the second causing clip inaccuracies. The fix is to make these values fractions where the first number is the number of frames for the startTime/duration, the second number (2500) relates to the frame rate (25 frames per second). So dividing the total frames by the frame rate gets us the total seconds. You can read more about it here:  https://www.fcp.co/final-cut-pro/tutorials/1912-demystifying-final-cut-pro-xmls-by-philip-hodgetts-and-gregory-clarke

note: if duration time is not divisible by 100, it seems to give a clip boundary warning in FCP, so have rounded this value