### PR TITLE
288-round start time

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ const jsonToFCPX = (sequenceEDLJson)=>{
         const results = composeAssetClip( {
             clipName: event.clipName, 
             ref:`r${counterIdAssetClips}`,
-            start: `${ event.startTime * FRAME_RATE }/${ FRAME_RATE }`,
+            start: `${ Math.round(event.startTime * FRAME_RATE) }/${ FRAME_RATE }`,
             duration: `${ roundedDuration }/${ FRAME_RATE }`
        })
         counterIdAssetClips=counterIdAssetClips+2;


### PR DESCRIPTION
fixes [#288](https://github.com/bbc/digital-paper-edit-firebase/issues/289)

fixes an issue where clips were missing in FCPX export.

**AC**
* when exporting FCPX the start time fraction should only contain integers 